### PR TITLE
Remove unused imports and clean warnings

### DIFF
--- a/mobile/lib/backend/api_requests/api_calls.dart
+++ b/mobile/lib/backend/api_requests/api_calls.dart
@@ -1,7 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
-import 'package:flutter/foundation.dart';
-
 import '/flutter_flow/flutter_flow_util.dart';
 import 'api_manager.dart';
 

--- a/mobile/lib/backend/api_requests/api_manager.dart
+++ b/mobile/lib/backend/api_requests/api_manager.dart
@@ -6,7 +6,6 @@ import 'dart:core';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:http/http.dart' as http;
 import 'package:equatable/equatable.dart';
 import 'package:http_parser/http_parser.dart';

--- a/mobile/lib/components/ai_chat_component/ai_chat_component_model.dart
+++ b/mobile/lib/components/ai_chat_component/ai_chat_component_model.dart
@@ -1,15 +1,7 @@
 import '/backend/api_requests/api_calls.dart';
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import 'ai_chat_component_widget.dart' show AiChatComponentWidget;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class AiChatComponentModel extends FlutterFlowModel<AiChatComponentWidget> {
   ///  State fields for stateful widgets in this component.

--- a/mobile/lib/components/ai_chat_component/ai_chat_component_widget.dart
+++ b/mobile/lib/components/ai_chat_component/ai_chat_component_widget.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'ai_chat_component_model.dart';
 export 'ai_chat_component_model.dart';
 

--- a/mobile/lib/components/termo/termo_model.dart
+++ b/mobile/lib/components/termo/termo_model.dart
@@ -1,11 +1,6 @@
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import 'termo_widget.dart' show TermoWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class TermoModel extends FlutterFlowModel<TermoWidget> {
   @override

--- a/mobile/lib/components/termo/termo_widget.dart
+++ b/mobile/lib/components/termo/termo_widget.dart
@@ -1,10 +1,8 @@
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'termo_model.dart';
 export 'termo_model.dart';
 

--- a/mobile/lib/flutter_flow/nav/nav.dart
+++ b/mobile/lib/flutter_flow/nav/nav.dart
@@ -10,8 +10,6 @@ import '/auth/base_auth_user_provider.dart';
 
 import '/main.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
-import '/flutter_flow/lat_lng.dart';
-import '/flutter_flow/place.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import 'serialization_util.dart';
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,16 +1,13 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'auth/firebase_auth/firebase_user_provider.dart';
 import 'auth/firebase_auth/auth_util.dart';
 
 import 'backend/firebase/firebase_config.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import 'flutter_flow/flutter_flow_util.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'flutter_flow/nav/nav.dart';
 import 'index.dart';
 

--- a/mobile/lib/pages/cadastro/cadastro_model.dart
+++ b/mobile/lib/pages/cadastro/cadastro_model.dart
@@ -1,16 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/backend/backend.dart';
-import '/components/termo/termo_widget.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'cadastro_widget.dart' show CadastroWidget;
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class CadastroModel extends FlutterFlowModel<CadastroWidget> {
   ///  State fields for stateful widgets in this page.

--- a/mobile/lib/pages/cadastro/cadastro_widget.dart
+++ b/mobile/lib/pages/cadastro/cadastro_widget.dart
@@ -4,12 +4,9 @@ import '/components/termo/termo_widget.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'cadastro_model.dart';
 export 'cadastro_model.dart';
 

--- a/mobile/lib/pages/chat/chat_model.dart
+++ b/mobile/lib/pages/chat/chat_model.dart
@@ -1,14 +1,7 @@
-import '/components/ai_chat_component/ai_chat_component_widget.dart';
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
+import '/components/ai_chat_component/ai_chat_component_model.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'chat_widget.dart' show ChatWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class ChatModel extends FlutterFlowModel<ChatWidget> {
   ///  State fields for stateful widgets in this page.

--- a/mobile/lib/pages/chat/chat_widget.dart
+++ b/mobile/lib/pages/chat/chat_widget.dart
@@ -2,12 +2,9 @@ import '/components/ai_chat_component/ai_chat_component_widget.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'chat_model.dart';
 export 'chat_model.dart';
 

--- a/mobile/lib/pages/login/login_model.dart
+++ b/mobile/lib/pages/login/login_model.dart
@@ -1,13 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'login_widget.dart' show LoginWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class LoginModel extends FlutterFlowModel<LoginWidget> {
   ///  State fields for stateful widgets in this page.

--- a/mobile/lib/pages/login/login_widget.dart
+++ b/mobile/lib/pages/login/login_widget.dart
@@ -2,11 +2,9 @@ import '/auth/firebase_auth/auth_util.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'login_model.dart';
 export 'login_model.dart';
 

--- a/mobile/lib/pages/main/main_model.dart
+++ b/mobile/lib/pages/main/main_model.dart
@@ -1,13 +1,6 @@
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'main_widget.dart' show MainWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class MainModel extends FlutterFlowModel<MainWidget> {
   @override

--- a/mobile/lib/pages/main/main_widget.dart
+++ b/mobile/lib/pages/main/main_widget.dart
@@ -2,11 +2,9 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'main_model.dart';
 export 'main_model.dart';
 

--- a/mobile/lib/pages/relatar_problema/relatar_problema_model.dart
+++ b/mobile/lib/pages/relatar_problema/relatar_problema_model.dart
@@ -1,17 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/backend/backend.dart';
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'relatar_problema_widget.dart' show RelatarProblemaWidget;
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class RelatarProblemaModel extends FlutterFlowModel<RelatarProblemaWidget> {
   ///  State fields for stateful widgets in this page.

--- a/mobile/lib/pages/relatar_problema/relatar_problema_widget.dart
+++ b/mobile/lib/pages/relatar_problema/relatar_problema_widget.dart
@@ -4,13 +4,10 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'relatar_problema_model.dart';
 export 'relatar_problema_model.dart';
 

--- a/mobile/lib/pages/senha/senha_model.dart
+++ b/mobile/lib/pages/senha/senha_model.dart
@@ -1,13 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'senha_widget.dart' show SenhaWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class SenhaModel extends FlutterFlowModel<SenhaWidget> {
   ///  State fields for stateful widgets in this page.

--- a/mobile/lib/pages/senha/senha_widget.dart
+++ b/mobile/lib/pages/senha/senha_widget.dart
@@ -2,11 +2,9 @@ import '/auth/firebase_auth/auth_util.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'senha_model.dart';
 export 'senha_model.dart';
 

--- a/mobile/lib/pages/usuario/usuario_model.dart
+++ b/mobile/lib/pages/usuario/usuario_model.dart
@@ -1,16 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/backend/backend.dart';
-import '/components/termo/termo_widget.dart';
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'usuario_widget.dart' show UsuarioWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class UsuarioModel extends FlutterFlowModel<UsuarioWidget> {
   @override

--- a/mobile/lib/pages/usuario/usuario_widget.dart
+++ b/mobile/lib/pages/usuario/usuario_widget.dart
@@ -5,11 +5,9 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'usuario_model.dart';
 export 'usuario_model.dart';
 

--- a/mobile/lib/pages/usuario_copy/usuario_copy_model.dart
+++ b/mobile/lib/pages/usuario_copy/usuario_copy_model.dart
@@ -1,16 +1,6 @@
-import '/auth/firebase_auth/auth_util.dart';
-import '/backend/backend.dart';
-import '/components/termo/termo_widget.dart';
-import '/flutter_flow/flutter_flow_icon_button.dart';
-import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
-import '/index.dart';
 import 'usuario_copy_widget.dart' show UsuarioCopyWidget;
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 
 class UsuarioCopyModel extends FlutterFlowModel<UsuarioCopyWidget> {
   @override

--- a/mobile/lib/pages/usuario_copy/usuario_copy_widget.dart
+++ b/mobile/lib/pages/usuario_copy/usuario_copy_widget.dart
@@ -5,11 +5,9 @@ import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
-import 'dart:ui';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
 import 'usuario_copy_model.dart';
 export 'usuario_copy_model.dart';
 


### PR DESCRIPTION
## Summary
- remove unused dependencies from Flutter entrypoint, navigation, and API helpers
- prune redundant imports across widgets and models to silence analyzer warnings

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6f46f6c148320b0c76bbca53a4c4f