### PR TITLE
Fix Dart analyzer warnings in FlutterFlow utilities

### DIFF
--- a/mobile/lib/backend/schema/util/firestore_util.dart
+++ b/mobile/lib/backend/schema/util/firestore_util.dart
@@ -1,7 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/material.dart';
-import 'package:from_css_color/from_css_color.dart';
-
 import '/backend/schema/util/schema_util.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 
@@ -17,7 +14,7 @@ abstract class FFFirebaseStruct extends BaseStruct {
   FFFirebaseStruct(this.firestoreUtilData);
 
   /// Utility class for Firestore updates
-  FirestoreUtilData firestoreUtilData = FirestoreUtilData();
+  FirestoreUtilData firestoreUtilData = const FirestoreUtilData();
 }
 
 class FirestoreUtilData {
@@ -125,7 +122,7 @@ Map<String, dynamic> mergeNestedFields(Map<String, dynamic> data) {
   final fieldNames = nestedData.keys.map((k) => k.split('.').first).toSet();
   // Remove nested values (e.g. 'foo.bar') and merge them into a map.
   data.removeWhere((k, _) => k.contains('.'));
-  fieldNames.forEach((name) {
+  for (final name in fieldNames) {
     final mergedValues = mergeNestedFields(
       nestedData
           .where((k, _) => k.split('.').first == name)
@@ -137,11 +134,15 @@ Map<String, dynamic> mergeNestedFields(Map<String, dynamic> data) {
         ...existingValue as Map<String, dynamic>,
       ...mergedValues,
     };
-  });
+  }
   // Merge any nested maps inside any of the fields as well.
-  data.where((_, v) => v is Map).forEach((k, v) {
-    data[k] = mergeNestedFields(v as Map<String, dynamic>);
-  });
+  final nestedMapEntries = data.entries
+      .where((entry) => entry.value is Map<String, dynamic>)
+      .toList();
+  for (final entry in nestedMapEntries) {
+    data[entry.key] =
+        mergeNestedFields(entry.value as Map<String, dynamic>);
+  }
 
   return data;
 }

--- a/mobile/lib/backend/schema/util/schema_util.dart
+++ b/mobile/lib/backend/schema/util/schema_util.dart
@@ -23,8 +23,8 @@ List<T>? getStructList<T>(
     value is! List
         ? null
         : value
-            .where((e) => e is Map<String, dynamic>)
-            .map((e) => structBuilder(e as Map<String, dynamic>))
+            .whereType<Map<String, dynamic>>()
+            .map(structBuilder)
             .toList();
 
 Color? getSchemaColor(dynamic value) => value is String

--- a/mobile/lib/components/termo/termo_widget.dart
+++ b/mobile/lib/components/termo/termo_widget.dart
@@ -43,26 +43,24 @@ class _TermoWidgetState extends State<TermoWidget> {
         color: Colors.transparent,
       ),
       child: Padding(
-        padding: EdgeInsetsDirectional.fromSTEB(16.0, 0.0, 16.0, 0.0),
+        padding: const EdgeInsetsDirectional.fromSTEB(16.0, 0.0, 16.0, 0.0),
         child: Container(
           width: double.infinity,
           decoration: BoxDecoration(
             color: FlutterFlowTheme.of(context).secondaryBackground,
             boxShadow: [
-              BoxShadow(
+              const BoxShadow(
                 blurRadius: 4.0,
                 color: Color(0x33000000),
-                offset: Offset(
-                  0.0,
-                  2.0,
-                ),
+                offset: Offset(0.0, 2.0),
                 spreadRadius: 0.0,
               )
             ],
             borderRadius: BorderRadius.circular(12.0),
           ),
           child: Padding(
-            padding: EdgeInsetsDirectional.fromSTEB(16.0, 16.0, 16.0, 16.0),
+            padding:
+                const EdgeInsetsDirectional.fromSTEB(16.0, 16.0, 16.0, 16.0),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -182,9 +180,10 @@ class _TermoWidgetState extends State<TermoWidget> {
                       options: FFButtonOptions(
                         width: 120.0,
                         height: 40.0,
-                        padding: EdgeInsets.all(8.0),
+                        padding: const EdgeInsets.all(8.0),
                         iconPadding:
-                            EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
+                            const EdgeInsetsDirectional.fromSTEB(
+                                0.0, 0.0, 0.0, 0.0),
                         color: FlutterFlowTheme.of(context).primary,
                         textStyle:
                             FlutterFlowTheme.of(context).bodyMedium.override(
@@ -206,7 +205,7 @@ class _TermoWidgetState extends State<TermoWidget> {
                                       .fontStyle,
                                 ),
                         elevation: 0.0,
-                        borderSide: BorderSide(
+                        borderSide: const BorderSide(
                           color: Colors.transparent,
                           width: 1.0,
                         ),
@@ -215,7 +214,7 @@ class _TermoWidgetState extends State<TermoWidget> {
                     ),
                   ],
                 ),
-              ].divide(SizedBox(height: 16.0)),
+              ].divide(const SizedBox(height: 16.0)),
             ),
           ),
         ),

--- a/mobile/lib/flutter_flow/flutter_flow_icon_button.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_icon_button.dart
@@ -3,7 +3,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class FlutterFlowIconButton extends StatefulWidget {
   const FlutterFlowIconButton({
-    Key? key,
+    super.key,
     required this.icon,
     this.borderColor,
     this.borderRadius,
@@ -19,7 +19,7 @@ class FlutterFlowIconButton extends StatefulWidget {
     this.showLoadingIndicator = false,
     this.focusBorderSide,
     this.focusBorderRadius,
-  }) : super(key: key);
+  });
 
   final Widget icon;
   final double? borderRadius;
@@ -83,9 +83,9 @@ class _FlutterFlowIconButtonState extends State<FlutterFlowIconButton> {
   @override
   Widget build(BuildContext context) {
     ButtonStyle style = ButtonStyle(
-      shape: MaterialStateProperty.resolveWith<OutlinedBorder>(
+      shape: WidgetStateProperty.resolveWith<OutlinedBorder>(
         (states) {
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(widget.borderRadius ?? 0),
               side: BorderSide(
@@ -113,26 +113,26 @@ class _FlutterFlowIconButtonState extends State<FlutterFlowIconButton> {
           );
         },
       ),
-      iconColor: MaterialStateProperty.resolveWith<Color?>(
+      iconColor: WidgetStateProperty.resolveWith<Color?>(
         (states) {
-          if (states.contains(MaterialState.disabled) &&
+          if (states.contains(WidgetState.disabled) &&
               widget.disabledIconColor != null) {
             return widget.disabledIconColor;
           }
-          if (states.contains(MaterialState.hovered) &&
+          if (states.contains(WidgetState.hovered) &&
               widget.hoverIconColor != null) {
             return widget.hoverIconColor;
           }
           return iconColor;
         },
       ),
-      backgroundColor: MaterialStateProperty.resolveWith<Color?>(
+      backgroundColor: WidgetStateProperty.resolveWith<Color?>(
         (states) {
-          if (states.contains(MaterialState.disabled) &&
+          if (states.contains(WidgetState.disabled) &&
               widget.disabledColor != null) {
             return widget.disabledColor;
           }
-          if (states.contains(MaterialState.hovered) &&
+          if (states.contains(WidgetState.hovered) &&
               widget.hoverColor != null) {
             return widget.hoverColor;
           }
@@ -140,8 +140,8 @@ class _FlutterFlowIconButtonState extends State<FlutterFlowIconButton> {
           return widget.fillColor;
         },
       ),
-      overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        if (states.contains(MaterialState.pressed)) {
+      overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.pressed)) {
           return null;
         }
         return widget.hoverColor == null ? null : Colors.transparent;
@@ -160,7 +160,7 @@ class _FlutterFlowIconButtonState extends State<FlutterFlowIconButton> {
           ignoring: (widget.showLoadingIndicator && loading),
           child: IconButton(
             icon: (widget.showLoadingIndicator && loading)
-                ? Container(
+                ? SizedBox(
                     width: iconSize,
                     height: iconSize,
                     child: CircularProgressIndicator(

--- a/mobile/lib/flutter_flow/flutter_flow_model.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_model.dart
@@ -51,9 +51,6 @@ abstract class FlutterFlowModel<W extends Widget> {
   // parameters of the widget, for example.
   W? _widget;
   W? get widget => _widget;
-  void set widget(W? newWidget) {
-    _widget = newWidget;
-  }
 
   // The context associated with this model.
   BuildContext? _context;
@@ -129,7 +126,11 @@ class FlutterFlowDynamicModels<T extends FlutterFlowModel> {
     return model != null ? getValue(model) : null;
   }
 
-  void dispose() => _childrenModels.values.forEach((model) => model.dispose());
+  void dispose() {
+    for (final model in _childrenModels.values) {
+      model.dispose();
+    }
+  }
 
   void _updateActiveKeys(String uniqueKey) {
     final shouldResetActiveKeys = _activeKeys == null;
@@ -142,12 +143,12 @@ class FlutterFlowDynamicModels<T extends FlutterFlowModel> {
       // this again next build.
       SchedulerBinding.instance.addPostFrameCallback((_) {
         _childrenIndexes.removeWhere((k, _) => !_activeKeys!.contains(k));
-        _childrenModels.keys
+        final keysToRemove = _childrenModels.keys
             .toSet()
-            .difference(_activeKeys!)
-            // Remove and dispose of unused models since they are  not being used
-            // elsewhere and would not otherwise be disposed.
-            .forEach((k) => _childrenModels.remove(k)?.maybeDispose());
+            .difference(_activeKeys!);
+        for (final key in keysToRemove) {
+          _childrenModels.remove(key)?.maybeDispose();
+        }
         _activeKeys = null;
       });
     }
@@ -156,13 +157,13 @@ class FlutterFlowDynamicModels<T extends FlutterFlowModel> {
 
 T? _getDefaultValue<T>() {
   switch (T) {
-    case int:
+    case int _:
       return 0 as T;
-    case double:
+    case double _:
       return 0.0 as T;
-    case String:
+    case String _:
       return '' as T;
-    case bool:
+    case bool _:
       return false as T;
     default:
       return null as T;

--- a/mobile/lib/flutter_flow/flutter_flow_util.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_util.dart
@@ -162,10 +162,10 @@ T? castToType<T>(dynamic value) {
     return null;
   }
   switch (T) {
-    case double:
+    case double _:
       // Doubles may be stored as ints in some cases.
       return value.toDouble() as T;
-    case int:
+    case int _:
       // Likewise, ints may be stored as doubles. If this is the case
       // (i.e. no decimal value), return the value as an int.
       if (value is num && value.toInt() == value) {
@@ -286,11 +286,11 @@ void showSnackbar(
         children: [
           if (loading)
             Padding(
-              padding: EdgeInsetsDirectional.only(end: 10.0),
-              child: Container(
+              padding: const EdgeInsetsDirectional.only(end: 10.0),
+              child: const SizedBox(
                 height: 20,
                 width: 20,
-                child: const CircularProgressIndicator(
+                child: CircularProgressIndicator(
                   color: Colors.white,
                 ),
               ),

--- a/mobile/lib/flutter_flow/flutter_flow_widgets.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_widgets.dart
@@ -130,8 +130,8 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
         : null;
 
     ButtonStyle style = ButtonStyle(
-      shape: MaterialStateProperty.resolveWith<OutlinedBorder>((states) {
-        if (states.contains(MaterialState.hovered) &&
+      shape: WidgetStateProperty.resolveWith<OutlinedBorder>((states) {
+        if (states.contains(WidgetState.hovered) &&
             widget.options.hoverBorderSide != null) {
           return RoundedRectangleBorder(
             borderRadius:
@@ -153,51 +153,51 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
           side: widget.options.borderSide ?? BorderSide.none,
         );
       }),
-      foregroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        if (states.contains(MaterialState.disabled) &&
+      foregroundColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.disabled) &&
             widget.options.disabledTextColor != null) {
           return widget.options.disabledTextColor;
         }
-        if (states.contains(MaterialState.hovered) &&
+        if (states.contains(WidgetState.hovered) &&
             widget.options.hoverTextColor != null) {
           return widget.options.hoverTextColor;
         }
         return widget.options.textStyle?.color ?? Colors.white;
       }),
-      backgroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        if (states.contains(MaterialState.disabled) &&
+      backgroundColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.disabled) &&
             widget.options.disabledColor != null) {
           return widget.options.disabledColor;
         }
-        if (states.contains(MaterialState.hovered) &&
+        if (states.contains(WidgetState.hovered) &&
             widget.options.hoverColor != null) {
           return widget.options.hoverColor;
         }
         return widget.options.color;
       }),
-      overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        if (states.contains(MaterialState.pressed)) {
+      overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.pressed)) {
           return widget.options.splashColor;
         }
         return widget.options.hoverColor == null ? null : Colors.transparent;
       }),
-      padding: MaterialStateProperty.all(
+      padding: WidgetStatePropertyAll(
         widget.options.padding ??
             const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
       ),
-      elevation: MaterialStateProperty.resolveWith<double?>((states) {
-        if (states.contains(MaterialState.hovered) &&
+      elevation: WidgetStateProperty.resolveWith<double?>((states) {
+        if (states.contains(WidgetState.hovered) &&
             widget.options.hoverElevation != null) {
           return widget.options.hoverElevation!;
         }
         return widget.options.elevation ?? 2.0;
       }),
-      iconColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        if (states.contains(MaterialState.disabled) &&
+      iconColor: WidgetStateProperty.resolveWith<Color?>((states) {
+        if (states.contains(WidgetState.disabled) &&
             widget.options.disabledTextColor != null) {
           return widget.options.disabledTextColor;
         }
-        if (states.contains(MaterialState.hovered) &&
+        if (states.contains(WidgetState.hovered) &&
             widget.options.hoverTextColor != null) {
           return widget.options.hoverTextColor;
         }
@@ -317,7 +317,7 @@ class FFFocusIndicator extends StatefulWidget {
   final void Function()? onDoubleTap;
 
   const FFFocusIndicator({
-    Key? key,
+    super.key,
     required this.child,
     this.border,
     this.borderRadius,
@@ -325,7 +325,7 @@ class FFFocusIndicator extends StatefulWidget {
     this.onTap,
     this.onLongPress,
     this.onDoubleTap,
-  }) : super(key: key);
+  });
 
   @override
   State<FFFocusIndicator> createState() => _FFFocusIndicatorState();

--- a/mobile/lib/flutter_flow/nav/nav.dart
+++ b/mobile/lib/flutter_flow/nav/nav.dart
@@ -1,17 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:page_transition/page_transition.dart';
 import 'package:provider/provider.dart';
-import '/backend/backend.dart';
 
 import '/auth/base_auth_user_provider.dart';
 
 import '/main.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import 'serialization_util.dart';
 
 import '/index.dart';
 
@@ -81,57 +77,59 @@ GoRouter createRouter(AppStateNotifier appStateNotifier) => GoRouter(
       refreshListenable: appStateNotifier,
       navigatorKey: appNavigatorKey,
       errorBuilder: (context, state) =>
-          appStateNotifier.loggedIn ? NavBarPage() : LoginWidget(),
+          appStateNotifier.loggedIn ? NavBarPage() : const LoginWidget(),
       routes: [
         FFRoute(
           name: '_initialize',
           path: '/',
           builder: (context, _) =>
-              appStateNotifier.loggedIn ? NavBarPage() : LoginWidget(),
+              appStateNotifier.loggedIn ? NavBarPage() : const LoginWidget(),
         ),
         FFRoute(
           name: LoginWidget.routeName,
           path: LoginWidget.routePath,
-          builder: (context, params) => LoginWidget(),
+          builder: (context, params) => const LoginWidget(),
         ),
         FFRoute(
           name: CadastroWidget.routeName,
           path: CadastroWidget.routePath,
-          builder: (context, params) => CadastroWidget(),
+          builder: (context, params) => const CadastroWidget(),
         ),
         FFRoute(
           name: MainWidget.routeName,
           path: MainWidget.routePath,
-          builder: (context, params) =>
-              params.isEmpty ? NavBarPage(initialPage: 'Main') : MainWidget(),
+          builder: (context, params) => params.isEmpty
+              ? NavBarPage(initialPage: 'Main')
+              : const MainWidget(),
         ),
         FFRoute(
           name: RelatarProblemaWidget.routeName,
           path: RelatarProblemaWidget.routePath,
           builder: (context, params) => params.isEmpty
               ? NavBarPage(initialPage: 'RelatarProblema')
-              : RelatarProblemaWidget(),
+              : const RelatarProblemaWidget(),
         ),
         FFRoute(
           name: ChatWidget.routeName,
           path: ChatWidget.routePath,
-          builder: (context, params) =>
-              params.isEmpty ? NavBarPage(initialPage: 'Chat') : ChatWidget(),
+          builder: (context, params) => params.isEmpty
+              ? NavBarPage(initialPage: 'Chat')
+              : const ChatWidget(),
         ),
         FFRoute(
           name: SenhaWidget.routeName,
           path: SenhaWidget.routePath,
-          builder: (context, params) => SenhaWidget(),
+          builder: (context, params) => const SenhaWidget(),
         ),
         FFRoute(
           name: UsuarioWidget.routeName,
           path: UsuarioWidget.routePath,
-          builder: (context, params) => UsuarioWidget(),
+          builder: (context, params) => const UsuarioWidget(),
         ),
         FFRoute(
           name: UsuarioCopyWidget.routeName,
           path: UsuarioCopyWidget.routePath,
-          builder: (context, params) => UsuarioCopyWidget(),
+          builder: (context, params) => const UsuarioCopyWidget(),
         )
       ].map((r) => r.toRoute(appStateNotifier)).toList(),
     );
@@ -369,7 +367,7 @@ class TransitionInfo {
   final Duration duration;
   final Alignment? alignment;
 
-  static TransitionInfo appDefault() => TransitionInfo(hasTransition: false);
+  static TransitionInfo appDefault() => const TransitionInfo(hasTransition: false);
 }
 
 class RootPageContext {


### PR DESCRIPTION
## Summary
- clean up Firestore utilities by removing redundant imports, using const defaults, and iterating without forEach closures
- adopt modern lint-compliant patterns across FlutterFlow widgets, including const constructors, WidgetStateProperty usage, and SizedBox substitutions
- streamline navigation setup by trimming unused imports and leveraging const widget constructors

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f700a5a8e88320bba16ab18e21db99