### PR TITLE
Resolve analyzer warnings in FlutterFlow-generated code

### DIFF
--- a/mobile/lib/backend/backend.dart
+++ b/mobile/lib/backend/backend.dart
@@ -213,7 +213,7 @@ Future<FFFirestorePage<T>> queryCollectionPage<T>(
   } else {
     docSnapshot = await query.get();
   }
-  final getDocs = (QuerySnapshot s) => s.docs
+  List<T> getDocs(QuerySnapshot s) => s.docs
       .map(
         (d) => safeGet(
           () => recordBuilder(d),

--- a/mobile/lib/components/ai_chat_component/ai_chat_component_widget.dart
+++ b/mobile/lib/components/ai_chat_component/ai_chat_component_widget.dart
@@ -2,7 +2,6 @@ import '/backend/api_requests/api_calls.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -69,10 +68,9 @@ class _AiChatComponentWidgetState extends State<AiChatComponentWidget> {
                       phone: false,
                       tablet: false,
                     ))
-                      Container(
+                      const SizedBox(
                         width: 100.0,
                         height: 24.0,
-                        decoration: BoxDecoration(),
                       ),
                     Expanded(
                       child: Padding(

--- a/mobile/lib/flutter_flow/flutter_flow_model.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_model.dart
@@ -156,18 +156,19 @@ class FlutterFlowDynamicModels<T extends FlutterFlowModel> {
 }
 
 T? _getDefaultValue<T>() {
-  switch (T) {
-    case int _:
-      return 0 as T;
-    case double _:
-      return 0.0 as T;
-    case String _:
-      return '' as T;
-    case bool _:
-      return false as T;
-    default:
-      return null as T;
+  if (T == int) {
+    return 0 as T;
   }
+  if (T == double) {
+    return 0.0 as T;
+  }
+  if (T == String) {
+    return '' as T;
+  }
+  if (T == bool) {
+    return false as T;
+  }
+  return null;
 }
 
 extension TextValidationExtensions on String? Function(BuildContext, String?)? {

--- a/mobile/lib/flutter_flow/flutter_flow_util.dart
+++ b/mobile/lib/flutter_flow/flutter_flow_util.dart
@@ -161,19 +161,16 @@ T? castToType<T>(dynamic value) {
   if (value == null) {
     return null;
   }
-  switch (T) {
-    case double _:
-      // Doubles may be stored as ints in some cases.
-      return value.toDouble() as T;
-    case int _:
-      // Likewise, ints may be stored as doubles. If this is the case
-      // (i.e. no decimal value), return the value as an int.
-      if (value is num && value.toInt() == value) {
-        return value.toInt() as T;
-      }
-      break;
-    default:
-      break;
+  if (T == double) {
+    // Doubles may be stored as ints in some cases.
+    return value.toDouble() as T;
+  }
+  if (T == int) {
+    // Likewise, ints may be stored as doubles. If this is the case
+    // (i.e. no decimal value), return the value as an int.
+    if (value is num && value.toInt() == value) {
+      return value.toInt() as T;
+    }
   }
   return value as T;
 }

--- a/mobile/lib/flutter_flow/nav/serialization_util.dart
+++ b/mobile/lib/flutter_flow/nav/serialization_util.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/material.dart';
 
 import '/backend/backend.dart';
@@ -243,7 +242,9 @@ dynamic deserializeParam<T>(
       case ParamType.documentReference:
         return _deserializeDocumentReference(param, collectionNamePath ?? []);
     }
-    return null;
+    // Exhaustive switch ensures this line is unreachable, but keep a fallback
+    // in case new enum values are added in the future.
+    throw StateError('Unsupported ParamType: $paramType');
   } catch (e) {
     debugPrint('Error deserializing parameter: $e');
     return null;

--- a/mobile/lib/pages/cadastro/cadastro_widget.dart
+++ b/mobile/lib/pages/cadastro/cadastro_widget.dart
@@ -531,15 +531,11 @@ class _CadastroWidgetState extends State<CadastroWidget> {
                                       safeSetState(() =>
                                           _model.checkboxValue = newValue!);
                                     },
-                                    side: (FlutterFlowTheme.of(context)
-                                                .alternate !=
-                                            null)
-                                        ? BorderSide(
-                                            width: 2,
-                                            color: FlutterFlowTheme.of(context)
-                                                .alternate!,
-                                          )
-                                        : null,
+                                    side: BorderSide(
+                                      width: 2,
+                                      color: FlutterFlowTheme.of(context)
+                                          .alternate,
+                                    ),
                                     activeColor:
                                         FlutterFlowTheme.of(context).secondary,
                                     checkColor:
@@ -670,6 +666,9 @@ class _CadastroWidgetState extends State<CadastroWidget> {
                                         uid: currentUserUid,
                                       ));
 
+                                  if (!context.mounted) {
+                                    return;
+                                  }
                                   context.pushNamedAuth(
                                       LoginWidget.routeName, context.mounted);
                                 }


### PR DESCRIPTION
## Summary
- convert inline closures into local functions to satisfy analyzer preferences in the Firestore pagination helper
- clean up FlutterFlow widgets by removing unused imports and updating theming/null-safety checks flagged by the analyzer
- replace unsupported type pattern switches and unreachable code in shared utilities and serialization helpers

## Testing
- Not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f70363319883208bb2bd38e730c13c