### PR TITLE
Fix Dart analyzer warnings

### DIFF
--- a/mobile/lib/auth/firebase_auth/apple_auth.dart
+++ b/mobile/lib/auth/firebase_auth/apple_auth.dart
@@ -9,7 +9,7 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 /// Generates a cryptographically secure random nonce, to be included in a
 /// credential request.
 String generateNonce([int length = 32]) {
-  final charset =
+  const charset =
       '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
   final random = Random.secure();
   return List.generate(length, (_) => charset[random.nextInt(charset.length)])

--- a/mobile/lib/auth/firebase_auth/firebase_user_provider.dart
+++ b/mobile/lib/auth/firebase_auth/firebase_user_provider.dart
@@ -8,6 +8,7 @@ export '../base_auth_user_provider.dart';
 class BusTrackerFirebaseUser extends BaseAuthUser {
   BusTrackerFirebaseUser(this.user);
   User? user;
+  @override
   bool get loggedIn => user != null;
 
   @override
@@ -23,13 +24,8 @@ class BusTrackerFirebaseUser extends BaseAuthUser {
   Future? delete() => user?.delete();
 
   @override
-  Future? updateEmail(String email) async {
-    try {
-      await user?.updateEmail(email);
-    } catch (_) {
-      await user?.verifyBeforeUpdateEmail(email);
-    }
-  }
+  Future? updateEmail(String email) async =>
+      user?.verifyBeforeUpdateEmail(email);
 
   @override
   Future? updatePassword(String newPassword) async {

--- a/mobile/lib/backend/api_requests/api_manager.dart
+++ b/mobile/lib/backend/api_requests/api_manager.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: constant_identifier_names, depend_on_referenced_packages, prefer_final_fields
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:io';

--- a/mobile/lib/backend/schema/pessoa_record.dart
+++ b/mobile/lib/backend/schema/pessoa_record.dart
@@ -3,16 +3,15 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 
 import '/backend/schema/util/firestore_util.dart';
-import '/backend/schema/util/schema_util.dart';
 
 import 'index.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 
 class PessoaRecord extends FirestoreRecord {
   PessoaRecord._(
-    DocumentReference reference,
-    Map<String, dynamic> data,
-  ) : super(reference, data) {
+    super.reference,
+    super.data,
+  ) {
     _initializeFields();
   }
 

--- a/mobile/lib/backend/schema/relatorio_record.dart
+++ b/mobile/lib/backend/schema/relatorio_record.dart
@@ -3,16 +3,15 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 
 import '/backend/schema/util/firestore_util.dart';
-import '/backend/schema/util/schema_util.dart';
 
 import 'index.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 
 class RelatorioRecord extends FirestoreRecord {
   RelatorioRecord._(
-    DocumentReference reference,
-    Map<String, dynamic> data,
-  ) : super(reference, data) {
+    super.reference,
+    super.data,
+  ) {
     _initializeFields();
   }
 

--- a/mobile/lib/pages/login/login_widget.dart
+++ b/mobile/lib/pages/login/login_widget.dart
@@ -350,7 +350,7 @@ class _LoginWidgetState extends State<LoginWidget> {
                                   _model.emailTextController.text,
                                   _model.senhaTextController.text,
                                 );
-                                if (!mounted) {
+                                if (!context.mounted) {
                                   return;
                                 }
                                 if (user == null) {
@@ -358,7 +358,7 @@ class _LoginWidgetState extends State<LoginWidget> {
                                 }
 
                                 context.goNamedAuth(
-                                    MainWidget.routeName, context.mounted);
+                                    MainWidget.routeName, mounted);
                               },
                               text: 'Login',
                               options: FFButtonOptions(

--- a/mobile/lib/pages/senha/senha_widget.dart
+++ b/mobile/lib/pages/senha/senha_widget.dart
@@ -208,7 +208,7 @@ class _SenhaWidgetState extends State<SenhaWidget> {
                                   context: context,
                                 );
 
-                                if (!mounted) {
+                                if (!context.mounted) {
                                   return;
                                 }
 

--- a/mobile/lib/pages/usuario/usuario_widget.dart
+++ b/mobile/lib/pages/usuario/usuario_widget.dart
@@ -4,7 +4,6 @@ import '/components/termo/termo_widget.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -492,10 +491,13 @@ class _UsuarioWidgetState extends State<UsuarioWidget> {
                         onTap: () async {
                           GoRouter.of(context).prepareAuthEvent();
                           await authManager.signOut();
+                          if (!context.mounted) {
+                            return;
+                          }
                           GoRouter.of(context).clearRedirectLocation();
 
                           context.goNamedAuth(
-                              LoginWidget.routeName, context.mounted);
+                              LoginWidget.routeName, mounted);
                         },
                         child: Container(
                           width: double.infinity,

--- a/mobile/lib/pages/usuario_copy/usuario_copy_widget.dart
+++ b/mobile/lib/pages/usuario_copy/usuario_copy_widget.dart
@@ -4,7 +4,6 @@ import '/components/termo/termo_widget.dart';
 import '/flutter_flow/flutter_flow_icon_button.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
-import '/flutter_flow/flutter_flow_widgets.dart';
 import '/index.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -545,10 +544,13 @@ class _UsuarioCopyWidgetState extends State<UsuarioCopyWidget> {
                         onTap: () async {
                           GoRouter.of(context).prepareAuthEvent();
                           await authManager.signOut();
+                          if (!context.mounted) {
+                            return;
+                          }
                           GoRouter.of(context).clearRedirectLocation();
 
                           context.goNamedAuth(
-                              LoginWidget.routeName, context.mounted);
+                              LoginWidget.routeName, mounted);
                         },
                         child: Container(
                           width: double.infinity,

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   firebase_performance: 0.10.1+7
   firebase_performance_platform_interface: 0.1.5+7
   firebase_performance_web: 0.1.7+13
+  crypto: 3.0.5
   flutter_animate: 4.5.0
   flutter_cache_manager: 3.4.1
   font_awesome_flutter: 10.7.0


### PR DESCRIPTION
## Summary
- annotate firebase user provider overrides and switch to verifyBeforeUpdateEmail
- add the crypto dependency and tidy related Apple sign-in helper
- address async context lints in login/user flows and remove redundant imports

## Testing
- Not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f7036e97d883209b50856c3110920d