### PR TITLE
Fix dead code lint in serialization utility

### DIFF
--- a/mobile/lib/flutter_flow/nav/serialization_util.dart
+++ b/mobile/lib/flutter_flow/nav/serialization_util.dart
@@ -241,10 +241,9 @@ dynamic deserializeParam<T>(
       case ParamType.document:
       case ParamType.documentReference:
         return _deserializeDocumentReference(param, collectionNamePath ?? []);
+      default:
+        throw StateError('Unsupported ParamType: $paramType');
     }
-    // Exhaustive switch ensures this line is unreachable, but keep a fallback
-    // in case new enum values are added in the future.
-    throw StateError('Unsupported ParamType: $paramType');
   } catch (e) {
     debugPrint('Error deserializing parameter: $e');
     return null;


### PR DESCRIPTION
## Summary
- add a default case to the ParamType switch in `deserializeParam`
- prevent unreachable fallback code flagged by the analyzer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f711082db88320bb14c3661e99aa4d