### PR TITLE
Streamline backend query helpers

### DIFF
--- a/mobile/lib/backend/backend.dart
+++ b/mobile/lib/backend/backend.dart
@@ -95,8 +95,7 @@ Future<int> queryCollectionCount(
   Query Function(Query)? queryBuilder,
   int limit = -1,
 }) async {
-  final builder = queryBuilder ?? (q) => q;
-  var query = builder(collection);
+  var query = (queryBuilder ?? (q) => q)(collection);
   if (limit > 0) {
     query = query.limit(limit);
   }
@@ -117,8 +116,7 @@ Stream<List<T>> queryCollection<T>(
   int limit = -1,
   bool singleRecord = false,
 }) {
-  final builder = queryBuilder ?? (q) => q;
-  var query = builder(collection);
+  var query = (queryBuilder ?? (q) => q)(collection);
   if (limit > 0 || singleRecord) {
     query = query.limit(singleRecord ? 1 : limit);
   }
@@ -143,8 +141,7 @@ Future<List<T>> queryCollectionOnce<T>(
   int limit = -1,
   bool singleRecord = false,
 }) {
-  final builder = queryBuilder ?? (q) => q;
-  var query = builder(collection);
+  var query = (queryBuilder ?? (q) => q)(collection);
   if (limit > 0 || singleRecord) {
     query = query.limit(singleRecord ? 1 : limit);
   }
@@ -200,8 +197,7 @@ Future<FFFirestorePage<T>> queryCollectionPage<T>(
   required int pageSize,
   required bool isStream,
 }) async {
-  final builder = queryBuilder ?? (q) => q;
-  var query = builder(collection).limit(pageSize);
+  var query = (queryBuilder ?? (q) => q)(collection).limit(pageSize);
   if (nextPageMarker != null) {
     query = query.startAfterDocument(nextPageMarker);
   }

--- a/mobile/lib/flutter_flow/nav/serialization_util.dart
+++ b/mobile/lib/flutter_flow/nav/serialization_util.dart
@@ -242,8 +242,6 @@ dynamic deserializeParam<T>(
       case ParamType.documentReference:
         return _deserializeDocumentReference(param, collectionNamePath ?? []);
     }
-    // Exhaustive switch ensures this line is unreachable, but keep a fallback
-    // in case new enum values are added in the future.
     throw StateError('Unsupported ParamType: $paramType');
   } catch (e) {
     debugPrint('Error deserializing parameter: $e');


### PR DESCRIPTION
## Summary
- inline the fallback query builder invocation in the backend query helpers to satisfy analyzer lints
- keep the existing error logging flow when fetching counts and documents

## Testing
- not run (environment not configured for Flutter)


------
https://chatgpt.com/codex/tasks/task_e_68f711082db88320bb14c3661e99aa4d