### PR TITLE
Fix missing kDebugMode import

### DIFF
--- a/mobile/lib/backend/api_requests/api_calls.dart
+++ b/mobile/lib/backend/api_requests/api_calls.dart
@@ -1,4 +1,7 @@
 import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
 import '/flutter_flow/flutter_flow_util.dart';
 import 'api_manager.dart';
 


### PR DESCRIPTION
## Summary
- add flutter foundation import to access kDebugMode constant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f71851bb8c832088af3fdb116a42aa